### PR TITLE
feat: add note export

### DIFF
--- a/background.js
+++ b/background.js
@@ -43,6 +43,7 @@ const close_settings = document.getElementById("close_settings");
 const settings_menu = document.getElementById("settings_menu");
 const newNoteButton = document.getElementById("newNote");
 const clearCacheButton = document.getElementById("clear-cache");
+const exportNotesButton = document.getElementById("export-notes");
 const searchInput = document.getElementById("search-input");
 const container = document.getElementById("mainBox"); // used for search filtering
 
@@ -211,7 +212,21 @@ function clearAllNotes() {
     newNote();
 }
 
+function exportNotes() {
+    const data = JSON.stringify(array, null, 2);
+    const blob = new Blob([data], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "notes.json";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
 clearCacheButton.onclick = clearAllNotes;
+exportNotesButton.onclick = exportNotes;
 
 window.onload = () => {
     console.log("[onload] Extension loaded");

--- a/popup.html
+++ b/popup.html
@@ -12,6 +12,11 @@
                 <ul>
                     <li>Light mode</li>
                     <li>
+                        <button id="export-notes" class="settings-button">
+                            <i class="fa-solid fa-file-export"></i> Export Notes
+                        </button>
+                    </li>
+                    <li>
                         <button id="clear-cache" class="settings-button">
                             <i class="fa-solid fa-trash-can"></i> Clear Cache
                         </button>


### PR DESCRIPTION
## Summary
- add button to settings menu for exporting notes
- implement JSON export of notes array

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e3a078560832b94c315f02fd4cd56