### PR TITLE
Add notes export feature with slide-in settings menu and light mode toggle

### DIFF
--- a/background.js
+++ b/background.js
@@ -43,8 +43,25 @@ const close_settings = document.getElementById("close_settings");
 const settings_menu = document.getElementById("settings_menu");
 const newNoteButton = document.getElementById("newNote");
 const clearCacheButton = document.getElementById("clear-cache");
+const exportButton = document.getElementById("export-notes");
+const lightModeToggle = document.getElementById("light-mode-toggle");
 const searchInput = document.getElementById("search-input");
 const container = document.getElementById("mainBox"); // used for search filtering
+
+if (lightModeToggle) {
+    chrome.storage.sync.get("lightMode", (res) => {
+        if (res.lightMode) {
+            body.classList.add("light-mode");
+            lightModeToggle.checked = true;
+        }
+    });
+
+    lightModeToggle.addEventListener("change", () => {
+        const enabled = lightModeToggle.checked;
+        body.classList.toggle("light-mode", enabled);
+        chrome.storage.sync.set({ lightMode: enabled });
+    });
+}
 
 /*************************************
 * NOTE CONSTRUCTORS
@@ -211,7 +228,33 @@ function clearAllNotes() {
     newNote();
 }
 
+function exportNotes() {
+    chrome.storage.sync.get("Table", (result) => {
+        let data = [];
+        if (result["Table"]) {
+            try {
+                data = JSON.parse(result["Table"]);
+            } catch (e) {
+                console.error("Error parsing Table:", e);
+            }
+        }
+
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "notes-export.json";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+
+        console.log("[exportNotes] Notes exported");
+    });
+}
+
 clearCacheButton.onclick = clearAllNotes;
+exportButton.onclick = exportNotes;
 
 window.onload = () => {
     console.log("[onload] Extension loaded");
@@ -223,11 +266,11 @@ window.onload = () => {
 function setupUI() {
     // Settings toggle
     settings.onclick = () => {
-        settings_menu.classList.toggle("expanded");
+        settings_menu.classList.toggle("open");
     };
 
     close_settings.onclick = () => {
-        settings_menu.classList.remove("expanded");
+        settings_menu.classList.remove("open");
     };
 
     // Search functionality

--- a/index.css
+++ b/index.css
@@ -45,6 +45,74 @@ body {
     width: 360px;
 }
 
+body.light-mode {
+    background-color: #fff;
+    background-image: radial-gradient(circle, #ccc 1px, transparent 0);
+    color: #000;
+}
+
+body.light-mode #newNote,
+body.light-mode .fa-gear {
+    color: black;
+}
+
+body.light-mode .title {
+    color: black;
+}
+
+body.light-mode #search-bar {
+    background: white;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+body.light-mode #search-input {
+    color: black;
+}
+
+body.light-mode .note {
+    background-color: #fff;
+    color: #000;
+}
+
+body.light-mode .note-title {
+    color: #000;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+body.light-mode .note-title::placeholder {
+    color: rgba(0, 0, 0, 0.5);
+}
+
+body.light-mode .noteContents {
+    color: #000;
+}
+
+body.light-mode #settings_menu {
+    background-color: #fff;
+    color: #000;
+}
+
+body.light-mode #close_settings {
+    color: #000;
+}
+
+body.light-mode .settings-button {
+    background: #eee;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    color: #000;
+}
+
+body.light-mode .style-actions,
+body.light-mode .trash-action {
+    background: rgba(0, 0, 0, 0.05);
+    -webkit-text-fill-color: black;
+    color: black;
+}
+
+body.light-mode .slider {
+    background-color: #ccc;
+}
+
 .mainBox {
     width: 100%;
     min-height: 100vh;
@@ -245,4 +313,113 @@ body {
         opacity: 1;
         transform: translateY(0);
     }
+}
+
+/* Settings side menu */
+#settings_menu {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 260px;
+    background-color: #222;
+    box-shadow: 2px 0 6px rgba(0, 0, 0, 0.4);
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    padding: 20px;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    pointer-events: none;
+}
+
+#settings_menu.open {
+    transform: translateX(0);
+    pointer-events: auto;
+}
+
+#close_settings {
+    color: white;
+    font-size: 30px;
+    cursor: pointer;
+    align-self: flex-start;
+}
+
+#settings_container ul {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 0;
+    margin: 0;
+}
+
+#settings_container ul li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: white;
+    font-family: Nunito, sans-serif;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 20px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #555;
+    transition: .2s;
+    border-radius: 20px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 16px;
+    width: 16px;
+    left: 2px;
+    bottom: 2px;
+    background-color: white;
+    transition: .2s;
+    border-radius: 50%;
+}
+
+input:checked + .slider {
+    background-color: #2196F3;
+}
+
+input:checked + .slider:before {
+    transform: translateX(20px);
+}
+
+.settings-button {
+    width: 100%;
+    padding: 8px 12px;
+    background: #333;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 6px;
+    color: white;
+    font-family: Nunito, sans-serif;
+    text-align: left;
+    cursor: pointer;
+}
+
+.settings-button i {
+    margin-right: 6px;
 }

--- a/popup.html
+++ b/popup.html
@@ -6,23 +6,28 @@
         <script src="lib/Sortable.min.js"></script>
     </head>
     <body>
-        <div id="settings_menu" style="display: none;">
-            <i id="close_settings" class="fa-solid fa-angle-left" style="color: white; position: absolute; top: 20; left: 20; font-size: 30px;"></i>
+        <div id="settings_menu">
+            <i id="close_settings" class="fa-solid fa-angle-left"></i>
             <div id="settings_container">
                 <ul>
-                    <li>Light mode</li>
+                    <li class="toggle-row">
+                        <span>Light mode</span>
+                        <label class="switch">
+                            <input type="checkbox" id="light-mode-toggle">
+                            <span class="slider round"></span>
+                        </label>
+                    </li>
                     <li>
                         <button id="clear-cache" class="settings-button">
                             <i class="fa-solid fa-trash-can"></i> Clear Cache
                         </button>
                     </li>
+                    <li>
+                        <button id="export-notes" class="settings-button">
+                            <i class="fa-solid fa-download"></i> Export Notes
+                        </button>
+                    </li>
                 </ul>
-            </div>
-            <div id="switch_container">
-                <label class="switch">
-                    <input type="checkbox">
-                    <span class="slider round"></span>
-                </label>
             </div>
         </div>
         <header class="header">


### PR DESCRIPTION
## Summary
- add export button in settings menu
- allow downloading saved notes as a JSON file
- redesign settings into a sliding left-side panel
- tidy up light mode toggle with switch styling and saved preference
- move settings close button above menu items on the left

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check background.js`


------
https://chatgpt.com/codex/tasks/task_e_688e3f9affa8832bbbae0ba9f54c5f2c