### PR TITLE
Adjust note spacing and popup sizing

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,5 +1,7 @@
 :root {
     --main-color: rgb(30, 30, 30);
+    --grid-unit: 20px;
+    --note-min-height: 125px;
 }
 .shadow {
     box-shadow:
@@ -34,11 +36,11 @@ body {
     font-family: 'Segoe UI', sans-serif;
     background-color: #111;
     background-image: radial-gradient(circle, #444 1px, transparent 0);
-    background-size: 20px 20px;
+    background-size: var(--grid-unit) var(--grid-unit);
     /* Shift the pattern by half the grid size so that the
        first dot sits at the origin rather than in the centre
        of the first tile. */
-    background-position: -10px -10px;
+    background-position: calc(var(--grid-unit) / -2) calc(var(--grid-unit) / -2);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -115,13 +117,15 @@ body.light-mode .slider {
 
 .mainBox {
     width: 100%;
-    min-height: 100vh;
     margin: 20px 0;
     padding-left: 20px;
     padding-right: 20px;
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: var(--grid-unit);
+    min-height: var(--note-min-height);
+    max-height: calc(var(--note-min-height) * 3 + var(--grid-unit) * 2);
+    overflow-y: auto;
     border-width: 1px;
     border-color: white;
     border-style: solid;
@@ -180,9 +184,8 @@ body.light-mode .slider {
 .note {
     position: relative;
     width: 100%;
-    min-height: 125px;
+    min-height: var(--note-min-height);
     padding: 5px;
-    margin-bottom: 12px;
     background-color: #222;
     border-radius: 10px;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Summary
- Align notes with a single grid unit between them and add CSS variables for grid sizing
- Resize popup container to show space for one note and grow up to three before scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68942ccb7508832bab2e9558938918a7