### PR TITLE
Randomize note placeholders

### DIFF
--- a/background.js
+++ b/background.js
@@ -31,6 +31,10 @@ const placeholders = [
     "Type. Don't think."
 ];
 
+function getRandomPlaceholder() {
+    return placeholders[Math.floor(Math.random() * placeholders.length)];
+}
+
 /**************************************
 * DOM REFERENCES
 **************************************/
@@ -76,6 +80,10 @@ function createNoteElement(noteObj) {
 
     titleInput.value = noteObj.title || "";
     bodyInput.innerHTML = noteObj.body || "";
+
+    if (!noteObj.body) {
+        bodyInput.setAttribute("data-placeholder", getRandomPlaceholder());
+    }
 
     clone.noteObj = noteObj;
     mainBox.appendChild(clone);


### PR DESCRIPTION
## Summary
- add helper to pick random note prompt
- set new notes' data-placeholder to random phrases

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68942fa551d4832bb515e59fc5c10f34