### PR TITLE
Fix note action styling

### DIFF
--- a/background.js
+++ b/background.js
@@ -165,7 +165,7 @@ function bindNoteEvents(clone, noteObj) {
                 document.execCommand(type, false, value);
             }
 
-            saveSelection();
+            restoreSelection();
             updateToolbar();
         });
     });

--- a/background.js
+++ b/background.js
@@ -110,14 +110,40 @@ function bindNoteEvents(clone, noteObj) {
     };
 
     const styleButtons = clone.querySelectorAll(".style-actions .action");
+
+    function isHighlighted() {
+        const current = document.queryCommandValue("hiliteColor");
+        return current === "rgb(255, 255, 0)" || current === "yellow";
+    }
+
+    function updateToolbar() {
+        styleButtons.forEach((btn) => {
+            const type = btn.dataset.type;
+            if (type === "hiliteColor") {
+                btn.classList.toggle("active", isHighlighted());
+            } else {
+                btn.classList.toggle("active", document.queryCommandState(type));
+            }
+        });
+    }
+
     styleButtons.forEach((btn) => {
         btn.addEventListener("mousedown", (e) => {
             e.preventDefault();
             const type = btn.dataset.type;
-            if (type) {
-                document.execCommand(type, false, null);
-                bodyInput.focus();
+            if (!type) return;
+
+            let value = btn.dataset.value || null;
+
+            if (type === "hiliteColor") {
+                const newColor = isHighlighted() ? "transparent" : value;
+                document.execCommand(type, false, newColor);
+            } else {
+                document.execCommand(type, false, value);
             }
+
+            bodyInput.focus();
+            updateToolbar();
         });
     });
 
@@ -127,12 +153,8 @@ function bindNoteEvents(clone, noteObj) {
         wordCount.innerText = words;
     });
 
-    bodyInput.addEventListener("keyup", () => {
-        styleButtons.forEach((btn) => {
-            const type = btn.dataset.type;
-            btn.classList.toggle("active", document.queryCommandState(type));
-        });
-    });
+    bodyInput.addEventListener("mouseup", updateToolbar);
+    bodyInput.addEventListener("keyup", updateToolbar);
 }
 
 // CONSTRUCT NEW NOTE //

--- a/background.js
+++ b/background.js
@@ -110,6 +110,22 @@ function bindNoteEvents(clone, noteObj) {
     };
 
     const styleButtons = clone.querySelectorAll(".style-actions .action");
+    let savedRange = null;
+
+    function saveSelection() {
+        const sel = window.getSelection();
+        if (sel.rangeCount > 0) {
+            savedRange = sel.getRangeAt(0);
+        }
+    }
+
+    function restoreSelection() {
+        if (savedRange) {
+            const sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(savedRange);
+        }
+    }
 
     function isHighlighted() {
         const current = document.queryCommandValue("hiliteColor");
@@ -130,10 +146,17 @@ function bindNoteEvents(clone, noteObj) {
     styleButtons.forEach((btn) => {
         btn.addEventListener("mousedown", (e) => {
             e.preventDefault();
+            bodyInput.focus();
+            restoreSelection();
+
             const type = btn.dataset.type;
             if (!type) return;
 
             let value = btn.dataset.value || null;
+            if (type === "createLink" && !value) {
+                value = prompt("Enter URL");
+                if (!value) return;
+            }
 
             if (type === "hiliteColor") {
                 const newColor = isHighlighted() ? "transparent" : value;
@@ -142,7 +165,7 @@ function bindNoteEvents(clone, noteObj) {
                 document.execCommand(type, false, value);
             }
 
-            bodyInput.focus();
+            saveSelection();
             updateToolbar();
         });
     });
@@ -153,8 +176,8 @@ function bindNoteEvents(clone, noteObj) {
         wordCount.innerText = words;
     });
 
-    bodyInput.addEventListener("mouseup", updateToolbar);
-    bodyInput.addEventListener("keyup", updateToolbar);
+    bodyInput.addEventListener("mouseup", () => { saveSelection(); updateToolbar(); });
+    bodyInput.addEventListener("keyup", () => { saveSelection(); updateToolbar(); });
 }
 
 // CONSTRUCT NEW NOTE //


### PR DESCRIPTION
## Summary
- Restore main note formatting logic to prevent actions from breaking note styling
- Allow highlight button to toggle off when the selected text is already highlighted

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check background.js`


------
https://chatgpt.com/codex/tasks/task_e_68a26fb4b788832bb04b4a544acbe578